### PR TITLE
feat: --config 配置文件（仅YAML）+ 启动参数 schema 单一化 (C1-C3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ export ASR_API_KEY=sk-your-key-here
 bash start.sh
 ```
 
+#### 配置文件（config.yaml）
+
+启动参数也可以通过 YAML 配置文件统一管理，不必每次写一长串命令行：
+
+```bash
+# 默认行为：自动加载 asr-service/config.yaml（支持 config.yml 别名）；
+# 首次启动若不存在，会自动从 config.example.yaml 拷贝生成一份可编辑的 config.yaml
+bash start.sh
+
+# 显式指定配置文件
+bash start.sh --config /path/to/my-config.yaml
+
+# 命令行参数临时覆盖配置文件（只影响本次启动，不改文件）
+bash start.sh --device cpu
+
+# 跳过配置文件（纯默认值 + 环境变量 + 命令行启动，排障用）
+bash start.sh --no-config
+```
+
+- **优先级**（低 → 高）：内置默认值 < 环境变量（`ASR_API_KEY`/`MODEL_SOURCE`）< 配置文件 < 命令行显式参数。
+- 配置键名 = 命令行长参数横线转下划线（如 `--model-size` → `model_size`），全部可配项见 [`asr-service/config.example.yaml`](asr-service/config.example.yaml)。
+- **删除 `config.yaml` 后重启 = 重置配置**（重新由 example 生成默认配置）。
+- 未知键 / 类型错误 / 取值越界会在启动时直接报错，防止拼写错误静默生效。
+- `config.yaml` 可能包含 `api_key`，已加入 `.gitignore`，请勿提交；`GET /health` 的 `config_file` 字段会回显本次生效的配置文件名。
+
 ### Docker 部署
 
 #### 使用预构建镜像

--- a/asr-service/.gitignore
+++ b/asr-service/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 *.pyo
 .env
 .cli_launch_config
+config.yaml
+config.yml

--- a/asr-service/app/api/schemas.py
+++ b/asr-service/app/api/schemas.py
@@ -60,4 +60,5 @@ class HealthResponse(BaseModel):
     asr_backend: str | None = None     # "qwen_asr" | "openvino"
     vad_backend: str | None = None     # "pytorch" | "onnx"
     punc_backend: str | None = None    # "pytorch" | "onnx"
+    config_file: str | None = None     # 本次生效的配置文件名（None = 未加载配置文件）
     capabilities: CapabilitiesResponse | None = None

--- a/asr-service/app/config.py
+++ b/asr-service/app/config.py
@@ -105,6 +105,10 @@ TASK_CLEANUP_INTERVAL = 300     # 清理扫描间隔（秒），默认 5 分钟
 
 SERVE_MODE = "standard"         # "standard" | "vllm"（由 main.py argparse 覆盖）
 
+# ─── 配置文件 ───
+
+CONFIG_FILE = None              # 本次生效的配置文件名（basename，/health 回显；None = 未加载）
+
 # ─── 实时流式转写（路线 B / WS /v2/asr/stream）───
 
 ENABLE_STREAM = False           # 是否挂载实时端点（standard 模式下 --enable-stream 开启）

--- a/asr-service/app/main.py
+++ b/asr-service/app/main.py
@@ -1,10 +1,11 @@
-import argparse
 import logging
 import sys
 import uvicorn
 from fastapi import FastAPI
 
 from app.utils.logger import setup_logger
+from app.utils.arg_schema import build_parser
+from app.utils.config_file import merge_runtime_config
 import app.config as cfg
 from app.runtime.device import detect_device, resolve_device, auto_select_model_size, should_disable_align
 from app.runtime.task_manager import TaskManager
@@ -19,74 +20,14 @@ from app.api.common_routes import init_common, build_common_router
 logger = logging.getLogger(__name__)
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Qwen3-ASR Service")
-    parser.add_argument(
-        "--serve-mode", dest="serve_mode", choices=["standard", "vllm"], default="standard",
-        help="服务运行模式：standard=transformers/OpenVINO 离线+实时(路线B)；"
-             "vllm=vLLM 原生流式(Phase 3) (default: standard)",
-    )
-    parser.add_argument(
-        "--device", choices=["auto", "cuda", "cpu"], default="auto",
-        help="运行设备 (default: auto)",
-    )
-    parser.add_argument(
-        "--model-size", choices=["0.6b", "1.7b"], default=None,
-        help="ASR 模型大小 (default: 根据显存自动选择)",
-    )
-    parser.add_argument(
-        "--enable-align", dest="enable_align", action="store_true", default=True,
-        help="加载对齐模型 (default)",
-    )
-    parser.add_argument(
-        "--no-align", dest="enable_align", action="store_false",
-        help="不加载对齐模型",
-    )
-    parser.add_argument(
-        "--use-punc", dest="enable_punc", action="store_true", default=False,
-        help="启用标点恢复",
-    )
-    parser.add_argument(
-        "--model-source", choices=["modelscope", "huggingface"], default="modelscope",
-        help="模型下载源 (default: modelscope)",
-    )
-    parser.add_argument(
-        "--host", default=None,
-        help="监听地址 (default: 127.0.0.1)",
-    )
-    parser.add_argument(
-        "--port", type=int, default=None,
-        help="监听端口 (default: 8765)",
-    )
-    parser.add_argument(
-        "--web", action="store_true", default=False,
-        help="启用 Web UI (访问 /web-ui)",
-    )
-    parser.add_argument(
-        "--max-segment", type=int, default=5,
-        help="VAD 切片合并最大时长，单位秒 (default: 5)",
-    )
-    parser.add_argument(
-        "--api-key", default=None,
-        help="API 密钥，设置后启用 Bearer token 认证（覆盖 ASR_API_KEY 环境变量）",
-    )
-    parser.add_argument(
-        "--max-queue-size", type=int, default=None,
-        help=f"任务队列最大长度 (default: {cfg.MAX_QUEUE_SIZE})",
-    )
-    parser.add_argument(
-        "--enable-stream", dest="enable_stream", action="store_true", default=False,
-        help="挂载实时转写端点 WS /v2/asr/stream（路线B，standard 模式）",
-    )
-    parser.add_argument(
-        "--max-stream-sessions", type=int, default=None,
-        help=f"实时最大并发会话数 (default: {cfg.MAX_STREAM_SESSIONS})",
-    )
-    parser.add_argument(
-        "--stream-asr-concurrency", type=int, default=None,
-        help=f"实时 ASR 解码并发上限 (default: {cfg.STREAM_ASR_CONCURRENCY})",
-    )
-    return parser.parse_args()
+def parse_args(argv=None):
+    """解析 CLI 并应用配置链：schema 默认值 < 环境变量 < 配置文件 < CLI 显式参数。
+
+    参数定义见 app/utils/arg_schema.py（单一 schema，argparse 全 SUPPRESS）；
+    配置文件的发现/引导生成/校验/合并见 app/utils/config_file.py。
+    """
+    cli_ns = build_parser().parse_args(argv)
+    return merge_runtime_config(cli_ns)
 
 
 def _apply_cli_config(args):
@@ -258,6 +199,7 @@ def _assemble_standard(app: FastAPI, args) -> None:
         "asr_backend": asr_backend,
         "vad_backend": VADEngine.BACKEND,
         "punc_backend": PuncEngine.BACKEND if enable_punc else "disabled",
+        "config_file": cfg.CONFIG_FILE,
         "capabilities": capabilities,
     }
 
@@ -334,6 +276,7 @@ def _assemble_vllm(app: FastAPI, args) -> None:
         "status": "ready",
         "mode": "vllm",
         "device": device,
+        "config_file": cfg.CONFIG_FILE,
         "capabilities": capabilities,
     }
 

--- a/asr-service/app/utils/arg_schema.py
+++ b/asr-service/app/utils/arg_schema.py
@@ -56,6 +56,7 @@ ARG_SPECS = (
         key="use_punc", flags=("--use-punc",), default=False, type=bool,
         dest="enable_punc",
         help="启用标点恢复",
+        negative_flags=("--no-punc",), negative_help="禁用标点恢复（覆盖配置文件）",
     ),
     ArgSpec(
         key="model_source", flags=("--model-source",), default="modelscope",
@@ -73,6 +74,7 @@ ARG_SPECS = (
     ArgSpec(
         key="web", flags=("--web",), default=False, type=bool,
         help="启用 Web UI (访问 /web-ui)",
+        negative_flags=("--no-web",), negative_help="禁用 Web UI（覆盖配置文件）",
     ),
     ArgSpec(
         key="max_segment", flags=("--max-segment",), default=5, type=int,
@@ -89,6 +91,7 @@ ARG_SPECS = (
     ArgSpec(
         key="enable_stream", flags=("--enable-stream",), default=False, type=bool,
         help="挂载实时转写端点 WS /v2/asr/stream（路线B，standard 模式）",
+        negative_flags=("--no-stream",), negative_help="不挂载实时转写端点（覆盖配置文件）",
     ),
     ArgSpec(
         key="max_stream_sessions", flags=("--max-stream-sessions",), default=None, type=int,

--- a/asr-service/app/utils/arg_schema.py
+++ b/asr-service/app/utils/arg_schema.py
@@ -1,0 +1,145 @@
+"""启动参数单一 schema：同一份定义驱动 argparse、配置文件校验与 config.example.yaml。
+
+设计要点（docs/plan/features/config_file/config-file-design.md §3.2）：
+- argparse 的 default 一律 SUPPRESS——否则无法区分"显式传了默认值"与"没传"，
+  配置文件的覆盖语义（默认值 < 环境变量 < 配置文件 < CLI 显式参数）会错；
+- 实义默认值收敛到本表（schema_defaults），消除 CLI 定义 / 文件校验 / 示例文件三处漂移；
+- key = 配置文件键名（CLI 长参数横线转下划线）；dest = argparse Namespace 属性名，
+  仅 --use-punc 二者不同（历史 dest=enable_punc，保持兼容）。
+"""
+import argparse
+from dataclasses import dataclass
+
+import app.config as cfg
+
+
+@dataclass(frozen=True)
+class ArgSpec:
+    key: str                      # 配置文件键名（= CLI 长参数横线转下划线）
+    flags: tuple                  # CLI flag（bool 型为"开启" flag）
+    default: object = None        # 实义默认值（argparse 一律 SUPPRESS）
+    type: type = str              # str / int / bool（bool 走 store_true/store_false）
+    choices: tuple = None
+    help: str = ""
+    dest: str = None              # argparse dest，缺省 = key
+    negative_flags: tuple = ()    # bool 开关对的"关闭" flag（如 --no-align）
+    negative_help: str = ""
+
+    @property
+    def attr(self) -> str:
+        return self.dest or self.key
+
+
+ARG_SPECS = (
+    ArgSpec(
+        key="serve_mode", flags=("--serve-mode",), default="standard",
+        choices=("standard", "vllm"),
+        help="服务运行模式：standard=transformers/OpenVINO 离线+实时(路线B)；"
+             "vllm=vLLM 原生流式(Phase 3) (default: standard)",
+    ),
+    ArgSpec(
+        key="device", flags=("--device",), default="auto",
+        choices=("auto", "cuda", "cpu"),
+        help="运行设备 (default: auto)",
+    ),
+    ArgSpec(
+        key="model_size", flags=("--model-size",), default=None,
+        choices=("0.6b", "1.7b"),
+        help="ASR 模型大小 (default: 根据显存自动选择)",
+    ),
+    ArgSpec(
+        key="enable_align", flags=("--enable-align",), default=True, type=bool,
+        help="加载对齐模型 (default)",
+        negative_flags=("--no-align",), negative_help="不加载对齐模型",
+    ),
+    ArgSpec(
+        key="use_punc", flags=("--use-punc",), default=False, type=bool,
+        dest="enable_punc",
+        help="启用标点恢复",
+    ),
+    ArgSpec(
+        key="model_source", flags=("--model-source",), default="modelscope",
+        choices=("modelscope", "huggingface"),
+        help="模型下载源 (default: modelscope)",
+    ),
+    ArgSpec(
+        key="host", flags=("--host",), default=None,
+        help="监听地址 (default: 127.0.0.1)",
+    ),
+    ArgSpec(
+        key="port", flags=("--port",), default=None, type=int,
+        help="监听端口 (default: 8765)",
+    ),
+    ArgSpec(
+        key="web", flags=("--web",), default=False, type=bool,
+        help="启用 Web UI (访问 /web-ui)",
+    ),
+    ArgSpec(
+        key="max_segment", flags=("--max-segment",), default=5, type=int,
+        help="VAD 切片合并最大时长，单位秒 (default: 5)",
+    ),
+    ArgSpec(
+        key="api_key", flags=("--api-key",), default=None,
+        help="API 密钥，设置后启用 Bearer token 认证（覆盖 ASR_API_KEY 环境变量）",
+    ),
+    ArgSpec(
+        key="max_queue_size", flags=("--max-queue-size",), default=None, type=int,
+        help=f"任务队列最大长度 (default: {cfg.MAX_QUEUE_SIZE})",
+    ),
+    ArgSpec(
+        key="enable_stream", flags=("--enable-stream",), default=False, type=bool,
+        help="挂载实时转写端点 WS /v2/asr/stream（路线B，standard 模式）",
+    ),
+    ArgSpec(
+        key="max_stream_sessions", flags=("--max-stream-sessions",), default=None, type=int,
+        help=f"实时最大并发会话数 (default: {cfg.MAX_STREAM_SESSIONS})",
+    ),
+    ArgSpec(
+        key="stream_asr_concurrency", flags=("--stream-asr-concurrency",), default=None, type=int,
+        help=f"实时 ASR 解码并发上限 (default: {cfg.STREAM_ASR_CONCURRENCY})",
+    ),
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """由 schema 生成 argparse：全参数 default=SUPPRESS（未传则不出现在 Namespace）。
+
+    --config / --no-config 为配置加载的元参数，不属于 schema（不能写进配置文件），
+    单独注册并保留普通 default。
+    """
+    parser = argparse.ArgumentParser(description="Qwen3-ASR Service")
+    for spec in ARG_SPECS:
+        if spec.type is bool:
+            parser.add_argument(
+                *spec.flags, dest=spec.attr, action="store_true",
+                default=argparse.SUPPRESS, help=spec.help,
+            )
+            if spec.negative_flags:
+                parser.add_argument(
+                    *spec.negative_flags, dest=spec.attr, action="store_false",
+                    default=argparse.SUPPRESS, help=spec.negative_help,
+                )
+        else:
+            kwargs = dict(dest=spec.attr, default=argparse.SUPPRESS, help=spec.help)
+            if spec.type is not str:
+                kwargs["type"] = spec.type
+            if spec.choices:
+                kwargs["choices"] = spec.choices
+            parser.add_argument(*spec.flags, **kwargs)
+
+    group = parser.add_argument_group("配置文件")
+    group.add_argument(
+        "--config", dest="config", default=None, metavar="PATH",
+        help="YAML 配置文件路径（缺省时自动发现 config.yaml/config.yml，"
+             "未发现则由 config.example.yaml 引导生成）",
+    )
+    group.add_argument(
+        "--no-config", dest="no_config", action="store_true", default=False,
+        help="跳过配置文件加载与引导生成（纯默认值+环境变量+CLI 启动）",
+    )
+    return parser
+
+
+def schema_defaults() -> dict:
+    """实义默认值表（dest 键），优先级链的第①层。"""
+    return {spec.attr: spec.default for spec in ARG_SPECS}

--- a/asr-service/app/utils/config_file.py
+++ b/asr-service/app/utils/config_file.py
@@ -9,6 +9,7 @@ import difflib
 import logging
 import os
 import shutil
+from collections.abc import Hashable
 
 import yaml
 
@@ -46,6 +47,7 @@ def resolve_config_path(cli_value: str | None, no_config: bool) -> str | None:
     if os.path.isfile(example):
         try:
             shutil.copyfile(example, yaml_path)   # 引导生成：首启即获得可编辑的真实配置
+            os.chmod(yaml_path, 0o600)            # 该文件后续可能写入 api_key，收紧为仅属主可读写
         except OSError as e:
             logger.warning(f"config.yaml 生成失败（{e}），本次直接加载 {EXAMPLE_NAME}")
             return example
@@ -55,6 +57,21 @@ def resolve_config_path(cli_value: str | None, no_config: bool) -> str | None:
     return None
 
 
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """重复键硬报错的 SafeLoader——YAML 规范默认末值静默胜出，
+    会掩盖配置文件中的拼写残留/合并事故，与"未知键硬报错"同一防线。"""
+
+    def construct_mapping(self, node, deep=False):
+        seen = set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if isinstance(key, Hashable):     # 不可哈希键交由父类按 YAML 规范报错
+                if key in seen:
+                    raise yaml.YAMLError(f"重复的配置键: {key}（第 {key_node.start_mark.line + 1} 行）")
+                seen.add(key)
+        return super().construct_mapping(node, deep)
+
+
 def load_config_file(path: str) -> dict:
     """YAML 解析 + schema 校验，返回 dest 键的扁平 dict。任何错误 SystemExit 带可读信息。
 
@@ -62,7 +79,7 @@ def load_config_file(path: str) -> dict:
     """
     try:
         with open(path, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f, Loader=_UniqueKeyLoader)
     except OSError as e:
         raise SystemExit(f"配置文件无法读取: {path}: {e}")
     except yaml.YAMLError as e:
@@ -87,17 +104,20 @@ def validate_config(data: dict, source: str = "<config>") -> dict:
         if value is None:
             errors.append(f"{key}: 值为空（如需使用默认值请删除该键）")
             continue
+        # 类型错误时附带合法值提示——最常见的笔误（如 model_size: 1.7 漏写 b 被 YAML
+        # 解析为浮点）应得到"可选 0.6b | 1.7b"而非干巴巴的类型报错
+        choices_hint = f"（可选 {' | '.join(spec.choices)}）" if spec.choices else ""
         if spec.type is bool:
             if not isinstance(value, bool):
-                errors.append(f"{key}: 期望 true/false，实得 {value!r}")
+                errors.append(f"{key}: 期望 true/false，实得 {value!r}{choices_hint}")
                 continue
         elif spec.type is int:
             if isinstance(value, bool) or not isinstance(value, int):
-                errors.append(f"{key}: 期望整数，实得 {value!r}")
+                errors.append(f"{key}: 期望整数，实得 {value!r}{choices_hint}")
                 continue
         else:
             if not isinstance(value, str):
-                errors.append(f"{key}: 期望字符串，实得 {value!r}")
+                errors.append(f"{key}: 期望字符串，实得 {value!r}{choices_hint}")
                 continue
         if spec.choices and value not in spec.choices:
             errors.append(f"{key}: 非法取值 {value!r}，可选 {' | '.join(spec.choices)}")

--- a/asr-service/app/utils/config_file.py
+++ b/asr-service/app/utils/config_file.py
@@ -1,0 +1,139 @@
+"""YAML 配置文件：自动发现 / 引导生成 / 校验 / 优先级合并。
+
+优先级链（低→高）：schema 默认值 < 环境变量(ASR_API_KEY/MODEL_SOURCE) < 配置文件 < CLI 显式参数。
+仅支持 YAML（config.yaml / config.yml）；键名 = CLI 长参数横线转下划线，扁平结构。
+设计文档：docs/plan/features/config_file/config-file-design.md §3
+"""
+import argparse
+import difflib
+import logging
+import os
+import shutil
+
+import yaml
+
+import app.config as cfg
+from app.utils.arg_schema import ARG_SPECS, schema_defaults
+
+logger = logging.getLogger(__name__)
+
+# 扫描根 = 服务根目录（start.sh 已 cd 至此），不扫调用者任意 cwd
+SERVICE_ROOT = cfg.BASE_DIR
+EXAMPLE_NAME = "config.example.yaml"
+
+
+def resolve_config_path(cli_value: str | None, no_config: bool) -> str | None:
+    """--no-config 短路；--config 显式优先；否则自动发现，未命中时由 example 引导生成。"""
+    if no_config:
+        return None
+    if cli_value is not None:
+        if not os.path.isfile(cli_value):
+            raise SystemExit(f"配置文件不存在: {cli_value}")
+        return cli_value
+
+    yaml_path = os.path.join(SERVICE_ROOT, "config.yaml")
+    yml_path = os.path.join(SERVICE_ROOT, "config.yml")
+    if os.path.isfile(yaml_path):
+        if os.path.isfile(yml_path):
+            logger.warning("config.yaml 与 config.yml 并存，已加载 config.yaml，忽略 config.yml")
+        logger.info("自动加载本地配置: config.yaml")
+        return yaml_path
+    if os.path.isfile(yml_path):
+        logger.info("自动加载本地配置: config.yml")
+        return yml_path
+
+    example = os.path.join(SERVICE_ROOT, EXAMPLE_NAME)
+    if os.path.isfile(example):
+        try:
+            shutil.copyfile(example, yaml_path)   # 引导生成：首启即获得可编辑的真实配置
+        except OSError as e:
+            logger.warning(f"config.yaml 生成失败（{e}），本次直接加载 {EXAMPLE_NAME}")
+            return example
+        logger.info(f"未发现 config.yaml，已从 {EXAMPLE_NAME} 生成默认配置")
+        return yaml_path
+    logger.warning(f"{EXAMPLE_NAME} 缺失，按内置默认值启动")
+    return None
+
+
+def load_config_file(path: str) -> dict:
+    """YAML 解析 + schema 校验，返回 dest 键的扁平 dict。任何错误 SystemExit 带可读信息。
+
+    显式指定与自动发现一视同仁：文件存在即意图明确，坏文件硬报错而非静默跳过。
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except OSError as e:
+        raise SystemExit(f"配置文件无法读取: {path}: {e}")
+    except yaml.YAMLError as e:
+        raise SystemExit(f"配置文件解析失败: {path}: {e}")
+    if not isinstance(data, dict):
+        raise SystemExit(f"配置文件须为顶层键值映射（空文件/列表/标量均不接受）: {path}")
+    return validate_config(data, source=path)
+
+
+def validate_config(data: dict, source: str = "<config>") -> dict:
+    """逐键校验：未知键（带近似提示）/ 空值 / 类型 / choices；通过则返回 dest 键 dict。"""
+    specs_by_key = {spec.key: spec for spec in ARG_SPECS}
+    errors = []
+    result = {}
+    for key, value in data.items():
+        spec = specs_by_key.get(key)
+        if spec is None:
+            close = difflib.get_close_matches(str(key), specs_by_key, n=1)
+            hint = f"（是否想写 {close[0]}？）" if close else ""
+            errors.append(f"未知配置键: {key}{hint}")
+            continue
+        if value is None:
+            errors.append(f"{key}: 值为空（如需使用默认值请删除该键）")
+            continue
+        if spec.type is bool:
+            if not isinstance(value, bool):
+                errors.append(f"{key}: 期望 true/false，实得 {value!r}")
+                continue
+        elif spec.type is int:
+            if isinstance(value, bool) or not isinstance(value, int):
+                errors.append(f"{key}: 期望整数，实得 {value!r}")
+                continue
+        else:
+            if not isinstance(value, str):
+                errors.append(f"{key}: 期望字符串，实得 {value!r}")
+                continue
+        if spec.choices and value not in spec.choices:
+            errors.append(f"{key}: 非法取值 {value!r}，可选 {' | '.join(spec.choices)}")
+            continue
+        result[spec.attr] = value
+    if errors:
+        raise SystemExit(f"配置文件校验失败: {source}\n  - " + "\n  - ".join(errors))
+    return result
+
+
+def merge_runtime_config(cli_ns: argparse.Namespace) -> argparse.Namespace:
+    """四层合并：schema 默认值 ← 环境变量 ← 配置文件 ← CLI 显式参数。
+
+    cli_ns 来自 build_parser()（全 SUPPRESS），仅含本次显式给出的参数；
+    生效配置文件名记入 cfg.CONFIG_FILE（/health 回显，防"幽灵配置"）。
+    """
+    cli = dict(vars(cli_ns))
+    no_config = cli.pop("no_config", False)
+    config_arg = cli.pop("config", None)
+
+    merged = schema_defaults()
+
+    # ② 环境变量（存量两项，空值视为未设置）
+    env_model_source = os.environ.get("MODEL_SOURCE")
+    if env_model_source:
+        merged["model_source"] = env_model_source
+    env_api_key = os.environ.get("ASR_API_KEY")
+    if env_api_key:
+        merged["api_key"] = env_api_key
+
+    # ③ 配置文件
+    path = resolve_config_path(config_arg, no_config)
+    if path is not None:
+        merged.update(load_config_file(path))
+    cfg.CONFIG_FILE = os.path.basename(path) if path else None
+
+    # ④ CLI 显式参数（最高，含"显式传默认值"）
+    merged.update(cli)
+    return argparse.Namespace(**merged)

--- a/asr-service/config.example.yaml
+++ b/asr-service/config.example.yaml
@@ -1,0 +1,33 @@
+# Qwen3-ASR Service 配置文件
+#
+# 首次启动时若无 config.yaml，将自动由本文件（config.example.yaml）拷贝生成 config.yaml；
+# 删除 config.yaml 后重启 = 重置为本文件的默认配置。
+# 优先级：命令行显式参数 > 本文件 > 环境变量 > 内置默认值；--no-config 可完全跳过本文件。
+# 注意：真实配置 config.yaml 可能含 api_key，已加入 .gitignore 请勿提交，建议 chmod 600 config.yaml。
+
+serve_mode: standard        # standard | vllm（vllm 为 Phase 3 占位，暂未实现，仅提供 /health /capabilities）
+device: cuda                # auto | cuda | cpu
+model_size: 0.6b            # 0.6b | 1.7b（删除本行 = 按显存自动选择）
+enable_align: false         # 词级时间戳对齐模型（需要时打开；CPU 模式不支持）
+use_punc: false             # 标点恢复
+model_source: modelscope    # modelscope | huggingface
+
+host: 127.0.0.1
+port: 8765
+web: true                   # /web-ui 演示页
+api_key: ""                 # 留空 = 不鉴权（本行会覆盖 ASR_API_KEY 环境变量；想用环境变量请删除本行）
+max_segment: 5              # VAD 切片合并最大时长（秒）
+# max_queue_size: 100       # 任务队列最大长度
+
+# ── 实时转写 ──
+enable_stream: true         # WS /v2/asr/stream（standard 模式）
+# max_stream_sessions: 16   # 实时最大并发会话数
+# stream_asr_concurrency: 1 # 实时 ASR 解码并发上限（模型层有推理锁，>1 无收益）
+
+# ── 预留：随对应特性落地后取消注释（当前版本写入会校验报错）──
+# enable_speaker: true            # 说话人分离
+# enable_speaker_db: true         # 声纹库（要求 api_key 非空，否则该模块自动降级关闭）
+# speaker_db_path: data/speakers.db
+# enable_task_store: true         # 离线任务持久化
+# task_db_path: data/tasks.db
+# task_retention_days: 7          # 过期任务清理窗口（启动时执行；0 = 永不清理）

--- a/asr-service/requirements-cpu.txt
+++ b/asr-service/requirements-cpu.txt
@@ -12,6 +12,9 @@ fastapi
 uvicorn[standard]
 python-multipart
 
+# 配置文件（funasr 已传递依赖，此处显式声明）
+pyyaml
+
 # 音频处理
 soundfile
 librosa

--- a/asr-service/requirements.txt
+++ b/asr-service/requirements.txt
@@ -11,6 +11,9 @@ fastapi
 uvicorn[standard]
 python-multipart
 
+# 配置文件（funasr 已传递依赖，此处显式声明）
+pyyaml
+
 # 音频处理
 soundfile
 librosa

--- a/asr-service/tests/unit/api/test_main_serve_mode.py
+++ b/asr-service/tests/unit/api/test_main_serve_mode.py
@@ -36,7 +36,8 @@ def isolated_create_app(tmp_path, monkeypatch):
     saved_handlers = root.handlers[:]
     saved_level = root.level
     keys = ("MODEL_SOURCE", "MAX_SEGMENT_DURATION", "HOST", "PORT", "API_KEY", "MAX_QUEUE_SIZE",
-            "SERVE_MODE", "ENABLE_STREAM", "MAX_STREAM_SESSIONS", "STREAM_ASR_CONCURRENCY")
+            "SERVE_MODE", "ENABLE_STREAM", "MAX_STREAM_SESSIONS", "STREAM_ASR_CONCURRENCY",
+            "CONFIG_FILE")
     snapshot = {k: getattr(cfg, k) for k in keys}
 
     yield
@@ -156,7 +157,8 @@ def test_config_stream_defaults():
 
 def test_parse_args_defaults(monkeypatch):
     from app.main import parse_args
-    monkeypatch.setattr("sys.argv", ["prog"])
+    # --no-config：隔离配置文件自动发现/引导生成，验证纯默认值与重构前一致
+    monkeypatch.setattr("sys.argv", ["prog", "--no-config"])
     args = parse_args()
     assert args.serve_mode == "standard"
     assert args.enable_stream is False
@@ -167,7 +169,7 @@ def test_parse_args_defaults(monkeypatch):
 def test_parse_args_stream_flags(monkeypatch):
     from app.main import parse_args
     monkeypatch.setattr("sys.argv", [
-        "prog", "--serve-mode", "standard", "--enable-stream",
+        "prog", "--no-config", "--serve-mode", "standard", "--enable-stream",
         "--max-stream-sessions", "8", "--stream-asr-concurrency", "3",
     ])
     args = parse_args()
@@ -176,11 +178,24 @@ def test_parse_args_stream_flags(monkeypatch):
     assert args.stream_asr_concurrency == 3
 
 
+def test_health_echoes_config_file(isolated_create_app, monkeypatch):
+    """/health 回显本次生效的配置文件名（防"幽灵配置"，vllm 占位分支即可覆盖）。"""
+    import app.config as cfg
+    from app.main import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_FILE", "config.yaml")
+    app = create_app(_args(serve_mode="vllm", device="cpu"))
+    client = TestClient(app)
+    assert client.get("/v1/health").json()["config_file"] == "config.yaml"
+    assert client.get("/v2/health").json()["config_file"] == "config.yaml"
+
+
 def test_apply_cli_config_writes_stream(monkeypatch):
     import app.config as cfg
     from app.main import _apply_cli_config, parse_args
     monkeypatch.setattr("sys.argv", [
-        "prog", "--enable-stream", "--max-stream-sessions", "5", "--stream-asr-concurrency", "4",
+        "prog", "--no-config", "--enable-stream",
+        "--max-stream-sessions", "5", "--stream-asr-concurrency", "4",
     ])
     saved = {k: getattr(cfg, k) for k in ("SERVE_MODE", "ENABLE_STREAM", "MAX_STREAM_SESSIONS",
                                           "STREAM_ASR_CONCURRENCY", "MODEL_SOURCE", "MAX_SEGMENT_DURATION")}

--- a/asr-service/tests/unit/utils/test_arg_schema.py
+++ b/asr-service/tests/unit/utils/test_arg_schema.py
@@ -66,9 +66,19 @@ def test_explicit_default_value_still_present():
     assert ns.device == "auto"
 
 
-def test_bool_pair_negative_flag():
-    ns = build_parser().parse_args(["--no-align"])
-    assert ns.enable_align is False
+@pytest.mark.parametrize("flag,attr", [
+    ("--no-align", "enable_align"),
+    ("--no-punc", "enable_punc"),
+    ("--no-web", "web"),
+    ("--no-stream", "enable_stream"),
+])
+def test_negative_flags_force_false(flag, attr):
+    """全部布尔开关都有反向 flag——CLI 才能把配置文件设 true 的开关覆盖回 false。"""
+    ns = build_parser().parse_args([flag])
+    assert getattr(ns, attr) is False
+
+
+def test_bool_pair_positive_flag():
     ns = build_parser().parse_args(["--enable-align"])
     assert ns.enable_align is True
 

--- a/asr-service/tests/unit/utils/test_arg_schema.py
+++ b/asr-service/tests/unit/utils/test_arg_schema.py
@@ -1,0 +1,93 @@
+"""app/utils/arg_schema.py 单一参数 schema 测试（C1：零行为变化重构）。
+
+核心断言：argparse 全 SUPPRESS——未传的参数不出现在 Namespace（覆盖语义的根基），
+schema 默认值与重构前 argparse 散落默认值逐项一致。
+"""
+import pytest
+
+from app.utils.arg_schema import ARG_SPECS, build_parser, schema_defaults
+
+
+# 重构前 main.py argparse 的默认值表（dest 键），作为零行为变化的基准
+LEGACY_DEFAULTS = {
+    "serve_mode": "standard",
+    "device": "auto",
+    "model_size": None,
+    "enable_align": True,
+    "enable_punc": False,
+    "model_source": "modelscope",
+    "host": None,
+    "port": None,
+    "web": False,
+    "max_segment": 5,
+    "api_key": None,
+    "max_queue_size": None,
+    "enable_stream": False,
+    "max_stream_sessions": None,
+    "stream_asr_concurrency": None,
+}
+
+
+def test_schema_defaults_match_legacy():
+    assert schema_defaults() == LEGACY_DEFAULTS
+
+
+def test_no_args_only_meta_keys():
+    """未传任何参数：Namespace 仅含 --config/--no-config 元参数，schema 参数全部缺席。"""
+    ns = build_parser().parse_args([])
+    assert vars(ns) == {"config": None, "no_config": False}
+
+
+@pytest.mark.parametrize("spec", ARG_SPECS, ids=lambda s: s.key)
+def test_each_spec_suppressed_when_absent(spec):
+    """逐参数断言：未传时不出现在 Namespace（SUPPRESS 改造无遗漏）。"""
+    ns = build_parser().parse_args([])
+    assert not hasattr(ns, spec.attr)
+
+
+@pytest.mark.parametrize("spec", ARG_SPECS, ids=lambda s: s.key)
+def test_each_spec_present_when_passed(spec):
+    """逐参数断言：显式传入后以正确 dest 与取值出现。"""
+    if spec.type is bool:
+        argv, expected = [spec.flags[0]], True
+    elif spec.choices:
+        argv, expected = [spec.flags[0], spec.choices[0]], spec.choices[0]
+    elif spec.type is int:
+        argv, expected = [spec.flags[0], "7"], 7
+    else:
+        argv, expected = [spec.flags[0], "value-x"], "value-x"
+    ns = build_parser().parse_args(argv)
+    assert getattr(ns, spec.attr) == expected
+
+
+def test_explicit_default_value_still_present():
+    """显式传默认值（--device auto）也出现在 Namespace——可覆盖配置文件（SUPPRESS 核心语义）。"""
+    ns = build_parser().parse_args(["--device", "auto"])
+    assert ns.device == "auto"
+
+
+def test_bool_pair_negative_flag():
+    ns = build_parser().parse_args(["--no-align"])
+    assert ns.enable_align is False
+    ns = build_parser().parse_args(["--enable-align"])
+    assert ns.enable_align is True
+
+
+def test_use_punc_dest_compat():
+    """--use-punc 的 dest 保持历史命名 enable_punc，配置文件键为 use_punc。"""
+    ns = build_parser().parse_args(["--use-punc"])
+    assert ns.enable_punc is True
+    spec = next(s for s in ARG_SPECS if s.key == "use_punc")
+    assert spec.attr == "enable_punc"
+
+
+def test_invalid_choice_rejected():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--device", "tpu"])
+
+
+def test_keys_and_dests_unique():
+    keys = [s.key for s in ARG_SPECS]
+    dests = [s.attr for s in ARG_SPECS]
+    assert len(set(keys)) == len(keys)
+    assert len(set(dests)) == len(dests)

--- a/asr-service/tests/unit/utils/test_config_file.py
+++ b/asr-service/tests/unit/utils/test_config_file.py
@@ -67,6 +67,8 @@ def test_bootstrap_copies_example(service_root):
     path = cf.resolve_config_path(None, False)
     assert path == str(service_root / "config.yaml")
     assert (service_root / "config.yaml").read_text(encoding="utf-8") == example.read_text(encoding="utf-8")
+    # 生成文件后续可能写入 api_key，必须仅属主可读写
+    assert (service_root / "config.yaml").stat().st_mode & 0o777 == 0o600
 
 
 def test_bootstrap_copy_failure_degrades_to_example(service_root, monkeypatch):
@@ -137,6 +139,19 @@ def test_type_and_choices_validation(service_root, data, msg):
         cf.validate_config(data)
 
 
+def test_duplicate_key_exits(service_root):
+    """YAML 规范默认重复键末值静默胜出——本服务按坏文件硬报错处理。"""
+    p = _write(service_root, "device: cpu\nport: 9000\ndevice: cuda\n")
+    with pytest.raises(SystemExit, match="重复的配置键: device"):
+        cf.load_config_file(p)
+
+
+def test_type_error_includes_choices_hint(service_root):
+    """最常见笔误 model_size: 1.7（YAML 浮点）应提示合法值，而非干巴巴的类型报错。"""
+    with pytest.raises(SystemExit, match=r"model_size: 期望字符串.*可选 0\.6b \| 1\.7b"):
+        cf.validate_config({"model_size": 1.7})
+
+
 def test_errors_are_aggregated(service_root):
     """多处错误一次性全部报出，不挤牙膏。"""
     with pytest.raises(SystemExit) as ei:
@@ -183,6 +198,14 @@ def test_merge_cli_explicit_default_over_file(service_root):
     _write(service_root, "device: cpu\n")
     merged = cf.merge_runtime_config(_ns(device="auto"))
     assert merged.device == "auto"
+
+
+def test_merge_cli_negative_bool_over_file(service_root):
+    """反向 flag（--no-stream 等）使 CLI 能把文件设 true 的布尔开关覆盖回 false。"""
+    _write(service_root, "enable_stream: true\nweb: true\n")
+    merged = cf.merge_runtime_config(_ns(enable_stream=False))
+    assert merged.enable_stream is False    # CLI 显式 false 胜过文件 true
+    assert merged.web is True               # 未覆盖的文件值保留
 
 
 def test_merge_records_config_file_basename(service_root):

--- a/asr-service/tests/unit/utils/test_config_file.py
+++ b/asr-service/tests/unit/utils/test_config_file.py
@@ -1,0 +1,207 @@
+"""app/utils/config_file.py 测试（C2）：自动发现/引导生成/校验/四层合并优先级。"""
+import argparse
+import os
+
+import pytest
+
+import app.config as cfg
+import app.utils.config_file as cf
+from app.utils.arg_schema import schema_defaults
+
+
+@pytest.fixture
+def service_root(tmp_path, monkeypatch):
+    """隔离扫描根到临时目录，并还原 cfg.CONFIG_FILE / 清空存量环境变量。"""
+    monkeypatch.setattr(cf, "SERVICE_ROOT", str(tmp_path))
+    monkeypatch.delenv("MODEL_SOURCE", raising=False)
+    monkeypatch.delenv("ASR_API_KEY", raising=False)
+    saved = cfg.CONFIG_FILE
+    yield tmp_path
+    cfg.CONFIG_FILE = saved
+
+
+def _ns(**explicit):
+    """模拟 build_parser() 输出：仅含元参数 + 本次显式给出的参数。"""
+    base = {"config": None, "no_config": False}
+    base.update(explicit)
+    return argparse.Namespace(**base)
+
+
+# ─── resolve_config_path ───
+
+def test_no_config_short_circuits_even_if_file_exists(service_root):
+    (service_root / "config.yaml").write_text("device: cpu", encoding="utf-8")
+    assert cf.resolve_config_path(None, no_config=True) is None
+
+
+def test_explicit_path_missing_exits(service_root):
+    with pytest.raises(SystemExit, match="配置文件不存在"):
+        cf.resolve_config_path(str(service_root / "nope.yaml"), no_config=False)
+
+
+def test_explicit_path_used_as_is(service_root):
+    p = service_root / "custom.yaml"
+    p.write_text("device: cpu", encoding="utf-8")
+    assert cf.resolve_config_path(str(p), no_config=False) == str(p)
+
+
+def test_autodiscover_yaml(service_root):
+    (service_root / "config.yaml").write_text("device: cpu", encoding="utf-8")
+    assert cf.resolve_config_path(None, False) == str(service_root / "config.yaml")
+
+
+def test_autodiscover_yml_alias(service_root):
+    (service_root / "config.yml").write_text("device: cpu", encoding="utf-8")
+    assert cf.resolve_config_path(None, False) == str(service_root / "config.yml")
+
+
+def test_coexist_prefers_yaml(service_root):
+    (service_root / "config.yaml").write_text("device: cpu", encoding="utf-8")
+    (service_root / "config.yml").write_text("device: cuda", encoding="utf-8")
+    assert cf.resolve_config_path(None, False) == str(service_root / "config.yaml")
+
+
+def test_bootstrap_copies_example(service_root):
+    example = service_root / "config.example.yaml"
+    example.write_text("device: cpu\nweb: true\n", encoding="utf-8")
+    path = cf.resolve_config_path(None, False)
+    assert path == str(service_root / "config.yaml")
+    assert (service_root / "config.yaml").read_text(encoding="utf-8") == example.read_text(encoding="utf-8")
+
+
+def test_bootstrap_copy_failure_degrades_to_example(service_root, monkeypatch):
+    example = service_root / "config.example.yaml"
+    example.write_text("device: cpu\n", encoding="utf-8")
+
+    def _fail(*a, **k):
+        raise OSError("read-only fs")
+
+    monkeypatch.setattr(cf.shutil, "copyfile", _fail)
+    assert cf.resolve_config_path(None, False) == str(example)
+
+
+def test_nothing_found_returns_none(service_root):
+    assert cf.resolve_config_path(None, False) is None
+
+
+# ─── load_config_file / validate_config ───
+
+def _write(service_root, text):
+    p = service_root / "config.yaml"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def test_load_valid_file_maps_dest_keys(service_root):
+    p = _write(service_root, "device: cpu\nuse_punc: true\nport: 9000\n")
+    assert cf.load_config_file(p) == {"device": "cpu", "enable_punc": True, "port": 9000}
+
+
+def test_load_empty_file_exits(service_root):
+    p = _write(service_root, "")
+    with pytest.raises(SystemExit, match="顶层键值映射"):
+        cf.load_config_file(p)
+
+
+def test_load_toplevel_list_exits(service_root):
+    p = _write(service_root, "- a\n- b\n")
+    with pytest.raises(SystemExit, match="顶层键值映射"):
+        cf.load_config_file(p)
+
+
+def test_load_broken_yaml_exits(service_root):
+    p = _write(service_root, "device: [unclosed\n")
+    with pytest.raises(SystemExit, match="解析失败"):
+        cf.load_config_file(p)
+
+
+def test_unknown_key_exits_with_hint(service_root):
+    with pytest.raises(SystemExit, match=r"未知配置键: divice（是否想写 device？）"):
+        cf.validate_config({"divice": "cpu"})
+
+
+def test_null_value_exits(service_root):
+    with pytest.raises(SystemExit, match="值为空"):
+        cf.validate_config({"model_size": None})
+
+
+@pytest.mark.parametrize("data,msg", [
+    ({"web": "yes"}, "期望 true/false"),
+    ({"port": "8765"}, "期望整数"),
+    ({"port": True}, "期望整数"),          # YAML bool 不得冒充 int
+    ({"host": 123}, "期望字符串"),
+    ({"device": "tpu"}, "非法取值"),
+])
+def test_type_and_choices_validation(service_root, data, msg):
+    with pytest.raises(SystemExit, match=msg):
+        cf.validate_config(data)
+
+
+def test_errors_are_aggregated(service_root):
+    """多处错误一次性全部报出，不挤牙膏。"""
+    with pytest.raises(SystemExit) as ei:
+        cf.validate_config({"divice": "cpu", "port": "x", "device": "tpu"})
+    text = str(ei.value)
+    assert "divice" in text and "port" in text and "device" in text
+
+
+# ─── merge_runtime_config 四层优先级 ───
+
+def test_merge_defaults_only(service_root):
+    merged = cf.merge_runtime_config(_ns(no_config=True))
+    assert vars(merged) == schema_defaults()
+    assert cfg.CONFIG_FILE is None
+
+
+def test_merge_env_over_defaults(service_root, monkeypatch):
+    monkeypatch.setenv("MODEL_SOURCE", "huggingface")
+    monkeypatch.setenv("ASR_API_KEY", "env-secret")
+    merged = cf.merge_runtime_config(_ns(no_config=True))
+    assert merged.model_source == "huggingface"
+    assert merged.api_key == "env-secret"
+
+
+def test_merge_file_over_env(service_root, monkeypatch):
+    monkeypatch.setenv("MODEL_SOURCE", "huggingface")
+    monkeypatch.setenv("ASR_API_KEY", "env-secret")
+    _write(service_root, 'model_source: modelscope\napi_key: ""\n')
+    merged = cf.merge_runtime_config(_ns())
+    assert merged.model_source == "modelscope"
+    assert merged.api_key == ""
+    assert cfg.CONFIG_FILE == "config.yaml"
+
+
+def test_merge_cli_over_file(service_root):
+    _write(service_root, "device: cpu\nport: 9000\n")
+    merged = cf.merge_runtime_config(_ns(device="cuda"))
+    assert merged.device == "cuda"      # CLI 显式最高
+    assert merged.port == 9000          # 未被 CLI 覆盖的文件值保留
+
+
+def test_merge_cli_explicit_default_over_file(service_root):
+    """显式传默认值（--device auto）也能覆盖文件值——SUPPRESS 语义验证。"""
+    _write(service_root, "device: cpu\n")
+    merged = cf.merge_runtime_config(_ns(device="auto"))
+    assert merged.device == "auto"
+
+
+def test_merge_records_config_file_basename(service_root):
+    p = service_root / "custom.yml"
+    p.write_text("device: cpu\n", encoding="utf-8")
+    cf.merge_runtime_config(_ns(config=str(p)))
+    assert cfg.CONFIG_FILE == "custom.yml"
+
+
+# ─── example 一致性（防示例与 schema 漂移）───
+
+def test_example_passes_schema_validation():
+    example = os.path.join(cfg.BASE_DIR, "config.example.yaml")
+    parsed = cf.load_config_file(example)
+    # 评审定稿的关键默认值组合（2026-06-04）
+    assert parsed["device"] == "cuda"
+    assert parsed["host"] == "127.0.0.1"
+    assert parsed["model_size"] == "0.6b"
+    assert parsed["enable_align"] is False
+    assert parsed["enable_stream"] is True
+    assert parsed["web"] is True
+    assert parsed["api_key"] == ""


### PR DESCRIPTION
## 概述

为日益增多的启动开关提供统一承载：支持 YAML 配置文件，命令行参数可临时覆盖。

## 核心变更

### C1 参数 schema 单一化（行为零变化重构）
- 新增 `app/utils/arg_schema.py`：15 个启动参数收敛为单一 `ARG_SPECS` 表，同时驱动 argparse、配置文件校验与示例文件
- argparse 全参数 `default=SUPPRESS`：可区分"显式传了默认值"与"没传"，这是覆盖语义的根基
- `--use-punc` 保持历史 dest=`enable_punc` 兼容

### C2 配置加载/校验/合并
- 新增 `app/utils/config_file.py`：
  - `--config <path>` 显式指定（不存在=硬错误）；缺省自动发现 `config.yaml` → `config.yml`（并存取 .yaml 并 WARN）
  - 未命中由 `config.example.yaml` **引导生成** config.yaml 再加载（删除 config.yaml = 重置配置）
  - 校验：未知键（带近似提示）/ 类型 / choices / 空文件 → 启动硬报错，一次性聚合报出
  - 四层优先级：内置默认值 < 环境变量（ASR_API_KEY/MODEL_SOURCE）< 配置文件 < CLI 显式参数
- `--no-config` 逃生口；`/health` 新增 `config_file` 字段回显（防幽灵配置）
- `config.example.yaml` 默认值按评审决议：cuda / 127.0.0.1 / 0.6b / align 关 / stream 开 / web 开
- `config.yaml`/`config.yml` 入 .gitignore（真实配置可含 api_key）

### C3 测试与文档
- 新增 57 项测试：逐参数 SUPPRESS 断言、发现/引导生成/校验/优先级全覆盖、example 与 schema 一致性防漂移
- README 新增配置文件章节

## 行为变化（评审决议的预期效果）
1. 裸跑 `bash start.sh` 将引导生成并加载 config.yaml（cuda/0.6b/web开/stream开），排障可用 `--no-config`
2. 环境变量 `MODEL_SOURCE` 此前实际被 argparse 默认值无条件覆盖（死配置），现按优先级链真正生效

## 测试
- 全量回归 **296 passed**（含新增 57 项）
- `--no-config` 下与重构前行为逐项一致（LEGACY_DEFAULTS 基准断言）

设计文档：`docs/plan/features/config_file/config-file-design.md`（本地，gitignored）