### PR TITLE
ci(docker): 新增 GitHub Actions 按 git tag 自动构建并推送三种镜像

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,108 @@
+name: Docker Publish
+
+# 推送 vX.Y.Z 形式的 git tag 时触发，自动构建并推送三种镜像变体到 Docker Hub。
+# GPU(amd64) / CPU(amd64) / ARM64 各自独立 job 并行执行。
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  IMAGE_NAME: lancelrq/qwen3-asr-service
+
+jobs:
+  # 从 tag 派生纯版本号（v2.0.1 -> 2.0.1），供各构建 job 复用
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.derive.outputs.version }}
+    steps:
+      - id: derive
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+  gpu:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      # GPU 镜像解压后约 8-10GB，标准 runner 默认可用磁盘不足，先清理腾出 20-30GB
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (GPU, amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.version }}
+            ${{ env.IMAGE_NAME }}:latest
+          push: true
+
+  cpu:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (CPU, amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.cpu
+          platforms: linux/amd64
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.version }}-cpu
+            ${{ env.IMAGE_NAME }}:latest-cpu
+          push: true
+
+  arm64:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # arm64 在 amd64 runner 上通过 QEMU 模拟构建
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (CPU, arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.cpu
+          platforms: linux/arm64
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.version }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.version }}-arm64
+            ${{ env.IMAGE_NAME }}:latest-arm64
+          push: true

--- a/asr-service/app/main.py
+++ b/asr-service/app/main.py
@@ -170,7 +170,7 @@ def create_app(args=None) -> FastAPI:
     _apply_cli_config(args)
 
     serve_mode = getattr(args, "serve_mode", "standard")
-    app = FastAPI(title="Qwen3-ASR Service", version="2.0.0")
+    app = FastAPI(title="Qwen3-ASR Service", version=os.environ.get("APP_VERSION", "2.0.0"))
     # 响应压缩（vendored 前端库 1.7MB → ~426KB；仅作用于 HTTP，WS 不受影响）
     app.add_middleware(GZipMiddleware, minimum_size=1024)
 

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -20,11 +20,11 @@ A simple, fast and efficient speech recognition API service based on Qwen3-ASR. 
 
 ### Image tag comparison
 
-| Tag | Base Image | Arch | Inference Engine | NVIDIA GPU | Image Size |
+| Tag | Base Image | Arch | Inference Engine | NVIDIA GPU | Image Size (compressed / on-disk) |
 |-----|-----------|------|-----------------|-----------|-----------|
-| `latest` / `2.0` | `nvidia/cuda:12.1.1-runtime-ubuntu22.04` | amd64 | PyTorch (CUDA) | Required | ~8-10GB |
-| `latest-cpu` / `2.0-cpu` | `ubuntu:22.04` | amd64 | OpenVINO (INT8) | Not required | ~3-4GB |
-| `latest-arm64` / `2.0-arm64` | `ubuntu:22.04` | arm64 | OpenVINO (FP32) | Not required | ~3-4GB |
+| `latest` / `2.0` | `nvidia/cuda:12.1.1-runtime-ubuntu22.04` | amd64 | PyTorch (CUDA) | Required | ~4.9GB / ~8-10GB |
+| `latest-cpu` / `2.0-cpu` | `ubuntu:22.04` | amd64 | OpenVINO (INT8) | Not required | ~2GB / ~3-4GB |
+| `latest-arm64` / `2.0-arm64` | `ubuntu:22.04` | arm64 | OpenVINO (FP32) | Not required | ~2GB / ~3-4GB |
 
 ### Features
 
@@ -219,11 +219,11 @@ If you find this project helpful, please consider giving a ⭐ on [GitHub](https
 
 ### 镜像版本对比
 
-| Tag | 基础镜像 | 架构 | 推理引擎 | NVIDIA GPU | 镜像体积 |
+| Tag | 基础镜像 | 架构 | 推理引擎 | NVIDIA GPU | 镜像体积（压缩 / 解压） |
 |-----|---------|------|---------|-----------|---------|
-| `latest` / `2.0` | `nvidia/cuda:12.1.1-runtime-ubuntu22.04` | amd64 | PyTorch (CUDA) | 需要 | ~8-10GB |
-| `latest-cpu` / `2.0-cpu` | `ubuntu:22.04` | amd64 | OpenVINO (INT8) | 不需要 | ~3-4GB |
-| `latest-arm64` / `2.0-arm64` | `ubuntu:22.04` | arm64 | OpenVINO (FP32) | 不需要 | ~3-4GB |
+| `latest` / `2.0` | `nvidia/cuda:12.1.1-runtime-ubuntu22.04` | amd64 | PyTorch (CUDA) | 需要 | ~4.9GB / ~8-10GB |
+| `latest-cpu` / `2.0-cpu` | `ubuntu:22.04` | amd64 | OpenVINO (INT8) | 不需要 | ~2GB / ~3-4GB |
+| `latest-arm64` / `2.0-arm64` | `ubuntu:22.04` | arm64 | OpenVINO (FP32) | 不需要 | ~2GB / ~3-4GB |
 
 ### 特性
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,10 @@ COPY asr-service/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --ignore-installed -r requirements.txt \
         --extra-index-url https://download.pytorch.org/whl/cu121
 
+# 镜像版本号（CI 按 git tag 注入，本地构建默认 dev）；置于依赖安装后，避免版本变更使 pip 层缓存失效
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 # 复制应用代码
 COPY asr-service/ /app
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -30,6 +30,10 @@ COPY asr-service/requirements-cpu.txt /app/requirements.txt
 RUN pip install --no-cache-dir --ignore-installed -r requirements.txt \
         --extra-index-url https://download.pytorch.org/whl/cpu
 
+# 镜像版本号（CI 按 git tag 注入，本地构建默认 dev）；置于依赖安装后，避免版本变更使 pip 层缓存失效
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 # 复制应用代码
 COPY asr-service/ /app
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -29,21 +29,28 @@ read -rp "请输入版本号（回车默认 latest）: " input_ver
 VER="${input_ver:-latest}"
 TAG="${VER}${SUFFIX}"
 
+# 注入镜像内版本号（FastAPI version / OpenAPI）；latest 不是有效语义版本，回退 dev
+if [ "$VER" = "latest" ]; then
+    APP_VER="dev"
+else
+    APP_VER="$VER"
+fi
+
 # 构建
 echo ""
 case "$VARIANT" in
     cpu)
         echo "Building ${IMAGE_NAME}:${TAG} (CPU, amd64) ..."
-        docker build -f docker/Dockerfile.cpu -t "${IMAGE_NAME}:${TAG}" .
+        docker build -f docker/Dockerfile.cpu --build-arg APP_VERSION="${APP_VER}" -t "${IMAGE_NAME}:${TAG}" .
         ;;
     arm64)
         echo "Building ${IMAGE_NAME}:${TAG} (CPU, arm64) ..."
         docker buildx build --platform linux/arm64 \
-            -f docker/Dockerfile.cpu -t "${IMAGE_NAME}:${TAG}" --load .
+            -f docker/Dockerfile.cpu --build-arg APP_VERSION="${APP_VER}" -t "${IMAGE_NAME}:${TAG}" --load .
         ;;
     *)
         echo "Building ${IMAGE_NAME}:${TAG} (GPU) ..."
-        docker build -f docker/Dockerfile -t "${IMAGE_NAME}:${TAG}" .
+        docker build -f docker/Dockerfile --build-arg APP_VERSION="${APP_VER}" -t "${IMAGE_NAME}:${TAG}" .
         ;;
 esac
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,7 @@
   - [5.4 实时 WebSocket](#54-实时-websocket)
 - [6. 本地起服务调试](#6-本地起服务调试)
 - [7. 提交约定](#7-提交约定)
+- [8. 发布与镜像构建](#8-发布与镜像构建)
 
 ---
 
@@ -134,3 +135,23 @@ venv/bin/python -m app.main --web --enable-stream \
 - 从默认分支切 feature 分支开发；提交信息用 Conventional Commits 前缀（`feat`/`fix`/`test`/`docs`…），正文中文。
 - `git add` 与 `git commit` **分开执行**（避免 index.lock）。
 - 改代码先跑相关单测；改了对外契约同步更新 `docs/api/` 文档与文档中心注册。
+
+## 8. 发布与镜像构建
+
+镜像发布由 GitHub Actions 自动完成：推送 `vX.Y.Z` 形式的 git tag 即触发 `.github/workflows/docker-publish.yml`，并行构建并推送三种变体到 Docker Hub。
+
+```bash
+git tag v2.0.1
+git push origin v2.0.1
+# → lancelrq/qwen3-asr-service:2.0.1 / 2.0.1-cpu / 2.0.1-arm64 + 对应 latest 系列
+```
+
+| 变体 | Dockerfile | 平台 | 产出 tag |
+|------|-----------|------|---------|
+| GPU | `docker/Dockerfile` | linux/amd64 | `X.Y.Z` + `latest` |
+| CPU | `docker/Dockerfile.cpu` | linux/amd64 | `X.Y.Z-cpu` + `latest-cpu` |
+| ARM64 | `docker/Dockerfile.cpu` | linux/arm64（QEMU） | `X.Y.Z-arm64` + `latest-arm64` |
+
+- **版本号注入**：tag 的版本号（去掉 `v` 前缀）经 `--build-arg APP_VERSION` 写入镜像，`main.py` 通过 `os.environ.get("APP_VERSION")` 读取，体现在 FastAPI `/openapi.json` 的 `info.version`。未注入时回退 `dev`（本地手工构建）/ `2.0.0`（源码直跑）。
+- **首次发版前置**：需在仓库 **Settings → Secrets and variables → Actions** 配置 `DOCKERHUB_USERNAME` 与 `DOCKERHUB_TOKEN`（Docker Hub Access Token，权限 Read & Write），否则登录步骤失败。
+- **本地手工构建**：仍可用 `bash docker/build.sh` 交互式构建单个变体（已同步注入 `APP_VERSION`）；CI 无 GPU，GPU 镜像的运行验证需本地有卡环境。

--- a/docs/development_EN.md
+++ b/docs/development_EN.md
@@ -17,6 +17,7 @@ For contributors: dev environment, testing, end-to-end smoke, key code conventio
   - [5.4 Realtime WebSocket](#54-realtime-websocket)
 - [6. Running the service locally](#6-running-the-service-locally)
 - [7. Commit conventions](#7-commit-conventions)
+- [8. Release & image build](#8-release--image-build)
 
 ---
 
@@ -134,3 +135,23 @@ venv/bin/python -m app.main --web --enable-stream \
 - Branch off the default branch for feature work; use Conventional Commits prefixes (`feat`/`fix`/`test`/`docs`…), Chinese body.
 - Run `git add` and `git commit` **separately** (avoid index.lock).
 - Run relevant unit tests before committing; when changing a public contract, update `docs/api/` docs and the doc-center registration.
+
+## 8. Release & image build
+
+Image publishing is automated via GitHub Actions: pushing a `vX.Y.Z` git tag triggers `.github/workflows/docker-publish.yml`, which builds and pushes three variants to Docker Hub in parallel.
+
+```bash
+git tag v2.0.1
+git push origin v2.0.1
+# → lancelrq/qwen3-asr-service:2.0.1 / 2.0.1-cpu / 2.0.1-arm64 + matching latest tags
+```
+
+| Variant | Dockerfile | Platform | Tags produced |
+|---------|-----------|----------|---------------|
+| GPU | `docker/Dockerfile` | linux/amd64 | `X.Y.Z` + `latest` |
+| CPU | `docker/Dockerfile.cpu` | linux/amd64 | `X.Y.Z-cpu` + `latest-cpu` |
+| ARM64 | `docker/Dockerfile.cpu` | linux/arm64 (QEMU) | `X.Y.Z-arm64` + `latest-arm64` |
+
+- **Version injection**: the tag's version (with the `v` prefix stripped) is passed via `--build-arg APP_VERSION` into the image; `main.py` reads it through `os.environ.get("APP_VERSION")`, surfacing as `info.version` in FastAPI `/openapi.json`. Falls back to `dev` (local manual build) / `2.0.0` (running source directly) when unset.
+- **First-release prerequisite**: configure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub Access Token with Read & Write) under repo **Settings → Secrets and variables → Actions**, otherwise the login step fails.
+- **Local manual build**: `bash docker/build.sh` still builds a single variant interactively (now also injects `APP_VERSION`); CI has no GPU, so runtime verification of the GPU image requires a local machine with a card.


### PR DESCRIPTION
推送 vX.Y.Z tag 触发 GPU/CPU/ARM64 三变体并行构建并推送 Docker Hub； tag 版本号经 build-arg APP_VERSION 注入镜像，main.py 改读环境变量； build.sh 同步注入；更新开发指南发布章节与 DOCKERHUB.md 体积描述。